### PR TITLE
Progress window on long operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-go-impl-methods",
-	"version": "0.0.0-develop",
+	"version": "0.0.0-development",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
At first, thank you for awesome extension!
This PR solves next problem:
When I trying implement interfaces not from stdlib, execution of `impl` takes very long time (up to 5-10 seconds). While it running for me as user not clear: is it running or not started? So having a progress window reassures me that the process is underway and there will be a result soon.